### PR TITLE
Force WIT to use Command Prompt

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -221,8 +221,13 @@ namespace DokaModInterface
 			// extract files using wit
 			Process? process = Process.Start(new ProcessStartInfo()
 			{
+#if WINDOWS
+				FileName = Path.Combine("C:", "Windows", "System32", "cmd.exe"),
+				Arguments = $"/c {Path.Combine("WIT", "wit.exe")} extract -o \"{open_iso_wbfs_dialog.FileName}\" \"DokaponFiles\""
+#else
 				FileName = Path.Combine("WIT", "wit.exe"),
 				Arguments = $"extract -o \"{open_iso_wbfs_dialog.FileName}\" \"DokaponFiles\""
+#endif
 			});
 			process?.WaitForExit();
 			process?.Close();


### PR DESCRIPTION
Launches cmd.exe with WIT/wit.exe as the argument. Tested and working.